### PR TITLE
Error working with file-paths which contains whitespaces

### DIFF
--- a/tasks/gjslint.js
+++ b/tasks/gjslint.js
@@ -51,15 +51,22 @@ module.exports = function(grunt) {
   function expandFiles(files) {
     var ret;
     if (files) {
-      ret = grunt.file.expand(files).filter(function(filepath) {
-        // Warn on and remove invalid source files (if nonull was set).
-        if (!grunt.file.exists(filepath)) {
-          grunt.log.warn('Source file "' + filepath + '" not found.');
-          return false;
-        } else {
-          return true;
-        }
-      }).join(' ');
+      ret = grunt.file.expand(files)
+        .filter(function(filepath) {
+          // Warn on and remove invalid source files (if nonull was set).
+          if (!grunt.file.exists(filepath)) {
+            grunt.log.warn('Source file "' + filepath + '" not found.');
+            return false;
+          } else {
+            return true;
+          }
+        })
+        .map(function(filePath) {
+          // Wrap the path between double quotes when whitespaces found.
+          return (filePath.indexOf(' ') === -1) ? filePath :
+            ['"', filePath, '"'].join('');
+        })
+        .join(' ');
     }
     return ret;
   }


### PR DESCRIPTION
The _gjslint_ _python_ tool is executed via command-line, and the separator of the file-paths and the options is the whitespace character. Therefore, when a path contains a whitespace, the _gjslint_ tool divides it in two different ones.

If these paths are well-formed the _gjslint_ ignores them, but if at least one of them starts with an invalid character, the tool reports an error.

Examples:
-  Path: `/usr/home/project name/test`
  - Command line: `gjslint /usr/home/project name/test`
  - Results:
    - `/usr/home/project` ok
    - `name/test` ok
-  Path: `/usr/home/project (name)/test`
  - Command line: `gjslint /usr/home/project (name)/test`
  - Results:
    - `/usr/home/project`: ok
    - `(name)/test`: error

The solution is to wrap the path between double quotes when it contains whitespaces:
-  Path: `/usr/home/project (name)/test`
  - Command line: `gjslint "/usr/home/project (name)/test"`
  - Results:
    - `/usr/home/projec (name)/test`: ok
