### PR TITLE
Added support for fixjsstyle.

### DIFF
--- a/.fixjsstylerc
+++ b/.fixjsstylerc
@@ -1,0 +1,2 @@
+--nojsdoc
+--debug_indentation

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,6 +43,20 @@ module.exports = function(grunt) {
         src: '<%= jshint.all %>'
       }
     },
+    fixjsstyle: {
+      options: {
+        flags: [
+          '--flagfile .fixjsstylerc'
+        ],
+        reporter: {
+          name: 'console'
+        },
+        force: true
+      },
+      all: {
+        src: '<%= jshint.all %>'
+      }
+    },
 
     // Unit tests.
     nodeunit: {

--- a/README.md
+++ b/README.md
@@ -17,15 +17,28 @@ One the plugin has been installed, it may be enabled inside your Gruntfile with 
 grunt.loadNpmTasks('grunt-gjslint');
 ```
 
-## The "gjslint" task
-Run this task with the `grunt gjslint` command.
+## The "gjslint" and "fixjsstyle" tasks
+Run this tasks with the `grunt gjslint` or `grunt fixjsstyle` commands.
 
 ### Overview
-In your project's Gruntfile, add a section named `gjslint` to the data object passed into `grunt.initConfig()`.
+In your project's Gruntfile, add sections named `gjslint` and `fixjsstyle` to the data object passed into `grunt.initConfig()`. Some of the flags passed to gjslint don't work with fixjsstyle.
 
 ```js
 grunt.initConfig({
   gjslint: {
+    options: {
+      flags: [
+        '--disable 220' //ignore error code 220 from gjslint
+      ],
+      reporter: {
+        name: 'console'
+      }
+    },
+    all: {
+      src: '<%= jshint.all %>'
+    }
+  },
+  fixjstyle: {
     options: {
       flags: [
         '--disable 220' //ignore error code 220 from gjslint
@@ -77,6 +90,23 @@ grunt.initConfig({
     test: {
       src: ['test/*.js'],
     }
+  },
+  fixjstyle: {
+    options: {
+      flags: [
+          '--flagfile .fixjssstylerc' //use flag file
+      ],
+      reporter: {
+        name: 'console' //report to console
+      },
+      force: false //don't fail if python is not installed on the computer
+    },
+    lib: {
+      src: ['lib/module/**/*.js', 'lib/foo.js'],
+    },
+    test: {
+      src: ['test/*.js'],
+    }
   }
 })
 ```
@@ -87,7 +117,10 @@ grunt.initConfig({
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
-* v0.1.4 
+* v0.1.5
+  * added fixjsstyle task
+
+* v0.1.4
   * bug fixing in filenames with whitespaces. Thanks to @moelders
 
 * v0.1.3 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-gjslint",
   "description": "Validate files with Google Closure Linter.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "homepage": "https://github.com/jmendiara/grunt-gjslint",
   "author": {
     "name": "Javier Mendiara Cañardo",
@@ -18,6 +18,10 @@
     {
       "name": "Jaime Pastor Pueyo",
       "email": "jppueyo@tid.es"
+    },
+    {
+      "name": "Sebastian Poręba",
+      "email": "sebastian@smashinglabs.pl"
     }
   ],
   "repository": {
@@ -53,6 +57,7 @@
   },
   "keywords": [
     "gjslint",
+    "fixjsstyle",
     "closure",
     "linter",
     "closure-linter",

--- a/tasks/gjslint.js
+++ b/tasks/gjslint.js
@@ -9,7 +9,7 @@
 'use strict';
 
 var gjslint = require('closure-linter-wrapper').gjslint;
-
+var fixjsstyle = require('closure-linter-wrapper').fixjsstyle;
 
 module.exports = function(grunt) {
 
@@ -30,6 +30,38 @@ module.exports = function(grunt) {
         var src = expandFiles(f.src);
 
         gjslint({
+          flags: options.flags,
+          reporter: options.reporter,
+          src: [src]
+        }, function(err, res) {
+          if (err) {
+            if (err.code === 1 && !options.force) {
+              done();
+            } else {
+              done(false);
+            }
+          } else {
+            done();
+          }
+        });
+      });
+    }
+  );
+
+  grunt.registerMultiTask('fixjsstyle', 'Fix files with Google Linter',
+    function() {
+      var done = this.async();
+      var options = this.options({
+        force: true,
+        reporter: {},
+        flags: []
+      });
+
+      // Iterate over all specified file groups.
+      this.files.forEach(function(f) {
+        var src = expandFiles(f.src);
+
+        fixjsstyle({
           flags: options.flags,
           reporter: options.reporter,
           src: [src]


### PR DESCRIPTION
Added configuration and description for fixjsstyle. It uses the same wrapper, just different set of flags. Unfortunately fixjsstyle does not ignore flags that are not supported but correct for gjslint, so two separated config files are required.
