### PR TITLE
If srcs is empty, finish analysis

### DIFF
--- a/tasks/gjslint.js
+++ b/tasks/gjslint.js
@@ -89,6 +89,11 @@ module.exports = function(grunt) {
       var doneCount = 0;
       var isDone = true;
 
+      if (srcs.length === 0) {
+        done(isDone);
+        return;
+      }
+
       var doneCheck = function(gjsDone) {
         if (!gjsDone) {
           isDone = false;


### PR DESCRIPTION
There was a problem. When you pass an empty array of files it never finished the execution. We use this tool in our pre-commit hook and it hangs everytime we commit some files that are ignored because the list of files to analyze is empty. This should fix it, by @jalopez